### PR TITLE
UI レイアウト改善

### DIFF
--- a/css/base.css
+++ b/css/base.css
@@ -6,13 +6,19 @@ body {
     Ubuntu, Cantarell, 'Open Sans', 'Helvetica Neue', sans-serif;
   background-color: #f5f5f5;
   color: #333;
+  height: 100vh;
+  width: 100vw;
+  overflow-x: hidden;
 }
 
 .container {
-  max-width: 800px;
+  width: 100%;
+  height: 100%;
   margin: 0 auto;
-  padding: 2rem;
-  padding-top: 1rem;
+  padding: 1rem;
+  box-sizing: border-box;
+  display: flex;
+  flex-direction: column;
 }
 
 h1 {
@@ -58,4 +64,22 @@ p {
 
 .font-bold {
   font-weight: 600;
+}
+
+/* メディアクエリ */
+@media (min-width: 768px) {
+  .container {
+    max-width: 800px;
+    padding: 1rem 2rem;
+  }
+}
+
+@media (max-width: 767px) {
+  h1 {
+    font-size: 2rem;
+  }
+  
+  h2 {
+    font-size: 1.5rem;
+  }
 }

--- a/css/components.css
+++ b/css/components.css
@@ -139,6 +139,10 @@ details {
   overflow: hidden;
 }
 
+.main-details {
+  margin-bottom: 20px;
+}
+
 summary {
   padding: 10px 15px;
   background-color: #f5f5f5;
@@ -173,4 +177,22 @@ details[open] summary::after {
 .details-content {
   padding: 15px;
   background-color: #f0f2ff;
+}
+
+/* メディアクエリの追加 */
+@media (max-width: 767px) {
+  .nav-tab {
+    padding: 0.6rem 0.8rem;
+    font-size: 0.9rem;
+  }
+  
+  .button-container {
+    flex-direction: column;
+    align-items: stretch;
+  }
+  
+  .popup-button {
+    width: 100%;
+    margin-bottom: 0.5rem;
+  }
 }

--- a/css/layout.css
+++ b/css/layout.css
@@ -6,6 +6,8 @@
   box-shadow: 0 2px 5px rgba(0, 0, 0, 0.05);
   position: relative;
   min-height: 300px; /* コンテンツ最小高さ */
+  flex: 1;
+  overflow-y: auto;
 }
 
 /* コンテンツビュー */
@@ -21,6 +23,7 @@
   transform: translateY(10px);
   pointer-events: none;
   transition: all 0.3s ease;
+  overflow-y: auto;
 }
 
 .view.active {
@@ -76,4 +79,28 @@
 
 .fade-out {
   animation: fadeOut 0.3s ease-in-out forwards;
+}
+
+/* レスポンシブデザイン */
+@media (max-width: 767px) {
+  .content-area {
+    padding: 1rem;
+  }
+  
+  .view {
+    padding: 1rem;
+  }
+}
+
+/* フレックスレイアウト設定 */
+.nav-tabs {
+  flex: 0 0 auto;
+  display: flex;
+  width: 100%;
+}
+
+.container {
+  display: flex;
+  flex-direction: column;
+  height: 100%;
 }

--- a/index.html
+++ b/index.html
@@ -2,6 +2,7 @@
 <html lang="ja">
   <head>
     <meta charset="UTF-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1.0">
     <title>Queuelip</title>
     <link rel="stylesheet" href="css/base.css">
     <link rel="stylesheet" href="css/components.css">
@@ -10,15 +11,6 @@
 
   <body>
     <div class="container">
-      <!-- ヘッダー情報 (アコーディオン) -->
-      <details>
-        <summary>詳細情報</summary>
-        <div class="details-content">
-          <h1>Queuelip</h1>
-          <p>キューの動作を持つクリップボードアプリ「Queuelip-キューリップ🌷🌷」</p>
-        </div>
-      </details>
-      
       <!-- タブナビゲーション -->
       <div class="nav-tabs">
         <button class="nav-tab active" data-view="main">メイン</button>
@@ -31,6 +23,15 @@
       <div class="content-area">
         <!-- メインビュー -->
         <div class="view view-main active" id="view-main">
+          <!-- ヘッダー情報 (アコーディオン) -->
+          <details class="main-details">
+            <summary>info</summary>
+            <div class="details-content">
+              <h1>Queuelip</h1>
+              <p>キューの動作を持つクリップボードアプリ「Queuelip-キューリップ🌷🌷」</p>
+            </div>
+          </details>
+          
           <h2>Hello World!</h2>
           <p>これはTauri + Rustで開発されたシンプルなアプリケーションです。</p>
           <p>上部のタブ、または以下のボタンをクリックして、各ビューに切り替えることができます。</p>
@@ -43,6 +44,17 @@
           </div>
           
           <div id="hover-status" class="hover-status">ホバー検知: 非アクティブ</div>
+          
+          <!-- フッター情報 (アコーディオン) -->
+          <details class="main-details">
+            <summary>version</summary>
+            <div class="details-content">
+              <footer class="app-footer">
+                <div id="version-info">バージョン: 0.1.102</div>
+                <div id="system-time">最終更新: 2025年05月16日 17:27:30</div>
+              </footer>
+            </div>
+          </details>
         </div>
         
         <!-- ビューA -->
@@ -72,17 +84,6 @@
           </div>
         </div>
       </div>
-      
-      <!-- フッター情報 (アコーディオン) -->
-      <details>
-        <summary>バージョン情報</summary>
-        <div class="details-content">
-          <footer class="app-footer">
-            <div id="version-info">バージョン: 0.1.102</div>
-            <div id="system-time">最終更新: 2025年05月16日 17:27:30</div>
-          </footer>
-        </div>
-      </details>
     </div>
 
     <!-- JavaScriptモジュールをインポート -->


### PR DESCRIPTION
## UI レイアウト改善

この PR では以下の変更を行いました：

1. **ヘッダーとフッターの変更**:
   - ヘッダー "詳細情報" → "info" に変更
   - フッター "バージョン情報" → "version" に変更

2. **レイアウト構造の改善**:
   - ヘッダーとフッターをメインビューの中に統合
   - トップコンテンツはタブビューのみに変更

3. **レスポンシブデザインの実装**:
   - 画面サイズに応じたレイアウト調整
   - Flexbox レイアウトの適用
   - モバイル端末対応のためのメディアクエリ追加

4. **コンテンツ幅の調整**:
   - 縦方向、横方向のコンテンツ幅を画面サイズとリンク

この PR はマージ後に、`[release]` を含むコミットメッセージでバージョンと日時を更新する必要があります。