### PR TITLE
タブキーによるフォーカス遷移の改善

### DIFF
--- a/css/utilities.css
+++ b/css/utilities.css
@@ -70,3 +70,34 @@
   background-color: #f9f9f9;
   transition: all 0.3s ease;
 }
+
+/* フォーカス制御のユーティリティクラス */
+.focus-control:focus {
+  outline: 2px solid #16a34a;
+  outline-offset: 2px;
+  box-shadow: 0 0 0 4px rgba(22, 163, 74, 0.2);
+}
+
+.focus-control-main:focus {
+  outline: 2px solid #2563eb;
+  outline-offset: 2px;
+  box-shadow: 0 0 0 4px rgba(37, 99, 235, 0.2);
+}
+
+.focus-control-a:focus {
+  outline: 2px solid #9333ea;
+  outline-offset: 2px;
+  box-shadow: 0 0 0 4px rgba(147, 51, 234, 0.2);
+}
+
+.focus-control-b:focus {
+  outline: 2px solid #db2777;
+  outline-offset: 2px;
+  box-shadow: 0 0 0 4px rgba(219, 39, 119, 0.2);
+}
+
+.focus-control-c:focus {
+  outline: 2px solid #16a34a;
+  outline-offset: 2px;
+  box-shadow: 0 0 0 4px rgba(22, 163, 74, 0.2);
+}

--- a/index.html
+++ b/index.html
@@ -14,10 +14,10 @@
     <div class="container">
       <!-- タブナビゲーション -->
       <div class="nav-tabs">
-        <button class="nav-tab active" data-view="main">メイン</button>
-        <button class="nav-tab" data-view="a">ビューA</button>
-        <button class="nav-tab" data-view="b">ビューB</button>
-        <button class="nav-tab" data-view="c">ビューC</button>
+        <button class="nav-tab active focus-control-main" data-view="main">メイン</button>
+        <button class="nav-tab focus-control-a" data-view="a">ビューA</button>
+        <button class="nav-tab focus-control-b" data-view="b">ビューB</button>
+        <button class="nav-tab focus-control-c" data-view="c">ビューC</button>
       </div>
       
       <!-- コンテンツエリア -->
@@ -26,7 +26,7 @@
         <div class="view view-main active" id="view-main">
           <!-- ヘッダー情報 (アコーディオン) -->
           <details class="main-details">
-            <summary>info</summary>
+            <summary class="focus-control-main">info</summary>
             <div class="details-content">
               <h1>Queuelip</h1>
               <p>キューの動作を持つクリップボードアプリ「Queuelip-キューリップ🌷🌷」</p>
@@ -39,20 +39,20 @@
           
           <!-- 以前のボタン (互換性のため残しています) -->
           <div class="button-container">
-            <button id="buttonA" class="popup-button">A</button>
-            <button id="buttonB" class="popup-button">B</button>
-            <button id="buttonC" class="popup-button">C</button>
+            <button id="buttonA" class="popup-button focus-control-a">A</button>
+            <button id="buttonB" class="popup-button focus-control-b">B</button>
+            <button id="buttonC" class="popup-button focus-control-c">C</button>
           </div>
           
           <div id="hover-status" class="hover-status">ホバー検知: 非アクティブ</div>
           
           <!-- フッター情報 (アコーディオン) -->
           <details class="main-details">
-            <summary>version</summary>
+            <summary class="focus-control-main">version</summary>
             <div class="details-content">
               <footer class="app-footer">
-                <div id="version-info">バージョン: 0.1.107</div>
-                <div id="system-time">最終更新: 2025年05月16日 16:05:00</div>
+                <div id="version-info">バージョン: 0.1.108</div>
+                <div id="system-time">最終更新: 2025年05月16日 16:16:00</div>
               </footer>
             </div>
           </details>

--- a/js/navigation.js
+++ b/js/navigation.js
@@ -10,6 +10,9 @@ export function setupTabButtons() {
       }
     });
   });
+
+  // 初期状態でのフォーカス制御を設定
+  setupTabFocusNavigation();
 }
 
 // ビューを切り替える
@@ -56,4 +59,70 @@ export function switchView(viewName) {
       newView.classList.remove('fade-in');
     }, 300); // アニメーション終了後にクラスを除去
   }
+
+  // タブフォーカスナビゲーションを更新
+  updateTabFocusNavigation(viewName);
+}
+
+// タブフォーカスナビゲーションの初期設定
+function setupTabFocusNavigation() {
+  // 現在のアクティブビューを取得
+  const activeView = document.querySelector('.view.active');
+  if (activeView) {
+    const viewName = activeView.id.replace('view-', '');
+    updateTabFocusNavigation(viewName);
+  }
+}
+
+// タブフォーカスナビゲーションを更新
+function updateTabFocusNavigation(activeViewName) {
+  // すべてのビューを取得
+  const views = document.querySelectorAll('.view');
+  
+  // 各ビューに対してフォーカス可能要素のtabindexを更新
+  views.forEach(view => {
+    const viewName = view.id.replace('view-', '');
+    const isCurrent = viewName === activeViewName;
+    
+    // ビュー内のフォーカス可能要素を取得
+    const focusableElements = view.querySelectorAll(
+      'button, [href], input, select, textarea, [tabindex]:not([tabindex="-1"])'
+    );
+    
+    // フォーカス可能要素のtabindexを更新
+    focusableElements.forEach(element => {
+      // 現在のビューの要素はフォーカス可能に、それ以外は不可に
+      if (isCurrent) {
+        // 元のtabindexがある場合はそれを復元、なければ削除
+        if (element.hasAttribute('data-original-tabindex')) {
+          const originalTabindex = element.getAttribute('data-original-tabindex');
+          if (originalTabindex !== null && originalTabindex !== '') {
+            element.setAttribute('tabindex', originalTabindex);
+          } else {
+            element.removeAttribute('tabindex');
+          }
+        }
+      } else {
+        // 現在のtabindexを保存し、フォーカス不可に設定
+        if (!element.hasAttribute('data-original-tabindex')) {
+          const currentTabindex = element.getAttribute('tabindex');
+          element.setAttribute('data-original-tabindex', currentTabindex || '');
+        }
+        element.setAttribute('tabindex', '-1');
+      }
+    });
+  });
+  
+  // タブボタンは常にフォーカス可能
+  const tabButtons = document.querySelectorAll('.nav-tab');
+  tabButtons.forEach(button => {
+    if (button.hasAttribute('data-original-tabindex')) {
+      const originalTabindex = button.getAttribute('data-original-tabindex');
+      if (originalTabindex !== null && originalTabindex !== '') {
+        button.setAttribute('tabindex', originalTabindex);
+      } else {
+        button.removeAttribute('tabindex');
+      }
+    }
+  });
 }


### PR DESCRIPTION
## 概要
タブキーによるフォーカス遷移の問題を修正しました。現在、例えばビューCを開いているときに、可視状態でないメインビューのfocusable要素にフォーカスされていました。このPRでは、現在表示されているビューの要素と上部タブだけにTabキーフォーカスが遷移するように修正しています。

## 変更内容
1. **navigation.js**:
   - タブ切り替え時にフォーカス制御を行う機能を追加
   - 非表示ビューの要素は`tabindex="-1"`に設定してフォーカス対象から除外
   - 表示ビューの要素は元のtabindex状態に復元

2. **utilities.css**:
   - フォーカス制御用のスタイルクラスを追加
   - ビューごとに異なるフォーカススタイルを定義

3. **index.html**:
   - フォーカス制御クラスを適用
   - バージョン番号を0.1.108に更新

## 動作確認方法
1. アプリケーションを起動
2. 任意のタブを開く
3. Tabキーを押して、フォーカスが現在表示されているビューの要素と上部タブのみを巡回することを確認