### PR TITLE
タブの文字サイズを小さくする

### DIFF
--- a/css/components.css
+++ b/css/components.css
@@ -14,7 +14,7 @@
   cursor: pointer;
   border: none;
   background-color: transparent;
-  font-size: 1rem;
+  font-size: 0.85rem;
   font-weight: 500;
   color: #495057;
   transition: all 0.3s ease;
@@ -206,7 +206,7 @@ details[open] summary::after {
 @media (max-width: 767px) {
   .nav-tab {
     padding: 0.6rem 0.8rem;
-    font-size: 0.9rem;
+    font-size: 0.8rem;
   }
   
   .button-container {


### PR DESCRIPTION
タブの文字サイズを小さくしました。
- PC表示: 1rem → 0.85rem
- モバイル表示: 0.9rem → 0.8rem