### PR TITLE
バージョン情報と最終更新日時の表示を別ファイルに分離

### DIFF
--- a/html/version-info.html
+++ b/html/version-info.html
@@ -1,0 +1,2 @@
+<div id="version-info">バージョン: 0.1.110</div>
+<div id="system-time">最終更新: 2025年05月16日 14:23:30</div>

--- a/index.html
+++ b/index.html
@@ -48,11 +48,10 @@
           
           <!-- フッター情報 (アコーディオン) -->
           <details class="main-details">
-            <summary>version</summary>
+            <summary class="focus-control-main">version</summary>
             <div class="details-content">
-              <footer class="app-footer">
-                <div id="version-info">バージョン: 0.1.110</div>
-                <div id="system-time">最終更新: 2025年05月16日 14:23:30</div>
+              <footer class="app-footer" id="app-footer">
+                <!-- バージョン情報はhtml/version-info.htmlから動的に読み込まれます -->
               </footer>
             </div>
           </details>

--- a/js/html-loader.js
+++ b/js/html-loader.js
@@ -1,0 +1,22 @@
+// HTML要素を動的に読み込むためのユーティリティ関数
+
+// 指定されたURLからHTMLを読み込み、指定された要素内にコンテンツを挿入する
+export async function loadHTML(url, targetElementId) {
+  try {
+    const response = await fetch(url);
+    if (!response.ok) {
+      throw new Error(`HTTP error! status: ${response.status}`);
+    }
+    const html = await response.text();
+    const targetElement = document.getElementById(targetElementId);
+    if (targetElement) {
+      targetElement.innerHTML = html;
+    } else {
+      console.error(`Target element with ID "${targetElementId}" not found.`);
+    }
+    return true;
+  } catch (error) {
+    console.error('Error loading HTML:', error);
+    return false;
+  }
+}

--- a/js/main.js
+++ b/js/main.js
@@ -3,10 +3,18 @@ import { updateSystemTime } from './time.js';
 import { setupHoverDetection } from './ui.js';
 import { setupTabButtons } from './navigation.js';
 import { setupLegacyButtons } from './legacy.js';
+import { initVersionInfo } from './version.js';
+import { loadHTML } from './html-loader.js';
 
 // Tauriアプリケーション初期化
 document.addEventListener('DOMContentLoaded', function() {
   console.log('Queuelip application initialized');
+  
+  // フッター情報を読み込む
+  loadHTML('./html/version-info.html', 'app-footer').then(() => {
+    // バージョン情報の初期化（HTMLロード後）
+    initVersionInfo();
+  });
   
   // 各モジュールの初期化
   updateSystemTime();

--- a/js/version.js
+++ b/js/version.js
@@ -1,0 +1,25 @@
+// バージョン情報と最終更新日時の管理
+const APP_VERSION = '0.1.110';
+const LAST_UPDATE = '2025年05月16日 14:23:30';
+
+// バージョン情報を画面に表示する
+export function displayVersionInfo() {
+  const versionInfoElement = document.getElementById('version-info');
+  if (versionInfoElement) {
+    versionInfoElement.textContent = `バージョン: ${APP_VERSION}`;
+  }
+}
+
+// 最終更新日時を画面に表示する
+export function displayLastUpdate() {
+  const systemTimeElement = document.getElementById('system-time');
+  if (systemTimeElement) {
+    systemTimeElement.textContent = `最終更新: ${LAST_UPDATE}`;
+  }
+}
+
+// バージョン情報と最終更新日時を初期化する
+export function initVersionInfo() {
+  displayVersionInfo();
+  displayLastUpdate();
+}


### PR DESCRIPTION
## 変更内容
- バージョン情報と最終更新日時を別ファイルに分離しました
- HTMLファイル (html/version-info.html) にバージョン情報と最終更新日時のHTMLを移動
- JavaScriptファイル (js/version.js) にバージョン情報と最終更新日時の管理機能を追加
- HTMLを動的に読み込むためのユーティリティ関数 (js/html-loader.js) を追加
- アプリケーション起動時にバージョン情報を動的に読み込む処理を追加

## 動作確認方法
- アプリケーションが起動したときにフッターにバージョン情報と最終更新日時が表示されることを確認
- version情報のアコーディオンをクリックして、バージョン情報と最終更新日時が正しく表示されることを確認