### PR TITLE
UI調整 バージョン情報をJS定数として分離

### DIFF
--- a/js/main.js
+++ b/js/main.js
@@ -3,18 +3,20 @@ import { updateSystemTime } from './time.js';
 import { setupHoverDetection } from './ui.js';
 import { setupTabButtons } from './navigation.js';
 import { setupLegacyButtons } from './legacy.js';
-import { initVersionInfo } from './version.js';
-import { loadHTML } from './html-loader.js';
+import { initVersionInfo, APP_VERSION, LAST_UPDATE } from './version.js';
 
 // Tauriアプリケーション初期化
 document.addEventListener('DOMContentLoaded', function() {
   console.log('Queuelip application initialized');
   
-  // フッター情報を読み込む
-  loadHTML('./html/version-info.html', 'app-footer').then(() => {
-    // バージョン情報の初期化（HTMLロード後）
-    initVersionInfo();
-  });
+  // フッター情報を直接挿入
+  const appFooter = document.getElementById('app-footer');
+  if (appFooter) {
+    appFooter.innerHTML = `
+      <div id="version-info">バージョン: ${APP_VERSION}</div>
+      <div id="system-time">最終更新: ${LAST_UPDATE}</div>
+    `;
+  }
   
   // 各モジュールの初期化
   updateSystemTime();

--- a/js/version.js
+++ b/js/version.js
@@ -1,6 +1,6 @@
 // バージョン情報と最終更新日時の管理
-const APP_VERSION = '0.1.110';
-const LAST_UPDATE = '2025年05月16日 14:23:30';
+export const APP_VERSION = '0.1.111';
+export const LAST_UPDATE = '2025年05月16日 16:50:00';
 
 // バージョン情報を画面に表示する
 export function displayVersionInfo() {


### PR DESCRIPTION
## 変更内容

- バージョン情報をハードコードから分離
- `js/version.js` にバージョン情報と最終更新日時を定数としてエクスポート
- `html/version-info.html` を読み込む代わりに、直接 JS から情報を取得

## 確認項目

- [x] バージョン表示が正しく更新される
- [x] システム日時が正しく表示される
- [x] 既存の機能に影響がない