### PR TITLE
Aビュー用のモーダルダイアログ機能追加

### DIFF
--- a/css/components.css
+++ b/css/components.css
@@ -202,6 +202,70 @@ details[open] summary::after {
   background-color: #f0f2ff;
 }
 
+/* モーダルダイアログ */
+.modal-dialog {
+  position: fixed;
+  top: 0;
+  left: 0;
+  width: 100%;
+  height: 100%;
+  background-color: rgba(255, 255, 255, 0.98);
+  display: flex;
+  flex-direction: column;
+  justify-content: center;
+  align-items: center;
+  z-index: 1000;
+  opacity: 0;
+  visibility: hidden;
+  transition: all 0.3s ease;
+}
+
+.modal-dialog.active {
+  opacity: 1;
+  visibility: visible;
+}
+
+.modal-header {
+  position: relative;
+  width: 100%;
+  padding: 1rem;
+  text-align: center;
+  background-color: #eff6ff;
+  border-bottom: 1px solid #d1d5db;
+}
+
+.modal-content {
+  padding: 2rem;
+  overflow-y: auto;
+  flex: 1;
+  width: 100%;
+  max-width: 800px;
+  margin: 0 auto;
+}
+
+.modal-close {
+  position: absolute;
+  top: 10px;
+  right: 10px;
+  background: transparent;
+  border: none;
+  font-size: 24px;
+  color: #2563eb;
+  cursor: pointer;
+  width: 30px;
+  height: 30px;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  border-radius: 50%;
+  transition: all 0.2s ease;
+}
+
+.modal-close:hover {
+  background-color: rgba(37, 99, 235, 0.1);
+  transform: scale(1.1);
+}
+
 /* メディアクエリの追加 */
 @media (max-width: 767px) {
   .nav-tab {
@@ -217,5 +281,9 @@ details[open] summary::after {
   .popup-button {
     width: 100%;
     margin-bottom: 0.5rem;
+  }
+  
+  .modal-content {
+    padding: 1rem;
   }
 }

--- a/index.html
+++ b/index.html
@@ -85,6 +85,21 @@
         </div>
       </div>
     </div>
+    
+    <!-- Aビュー用モーダルダイアログ -->
+    <div class="modal-dialog" id="a-modal-dialog">
+      <div class="modal-header">
+        <h2>ビューA - モーダルダイアログ</h2>
+        <button class="modal-close" id="modal-close">&times;</button>
+      </div>
+      <div class="modal-content">
+        <div class="text-center">
+          <div class="text-xl font-bold mb-4" style="color: #2563eb;">ビューAのモーダルコンテンツ</div>
+          <p class="mb-4">これはビューAで表示されるモーダルダイアログです。画面いっぱいに表示され、右上の×ボタンをクリックすると閉じることができます。</p>
+          <p>このダイアログ内に今後、ビューA専用の機能を実装していきます。</p>
+        </div>
+      </div>
+    </div>
 
     <!-- JavaScriptモジュールをインポート -->
     <script type="module" src="js/main.js"></script>

--- a/js/legacy.js
+++ b/js/legacy.js
@@ -1,5 +1,5 @@
-// navigation.jsからswitchView関数をインポート
-import { switchView } from './navigation.js';
+// navigation.jsからswitchViewとshowAViewModal関数をインポート
+import { switchView, showAViewModal } from './navigation.js';
 
 // レガシーボタンの設定
 export function setupLegacyButtons() {
@@ -10,6 +10,8 @@ export function setupLegacyButtons() {
   if (buttonA) {
     buttonA.addEventListener('click', function() {
       switchView('a');
+      // Aボタンクリック時にもモーダルを表示
+      showAViewModal();
     });
   }
   

--- a/js/navigation.js
+++ b/js/navigation.js
@@ -7,6 +7,11 @@ export function setupTabButtons() {
       const viewName = this.getAttribute('data-view');
       if (viewName) {
         switchView(viewName);
+        
+        // ビューAの場合はモーダルダイアログを表示
+        if (viewName === 'a') {
+          showAViewModal();
+        }
       }
     });
   });
@@ -55,5 +60,30 @@ export function switchView(viewName) {
     setTimeout(() => {
       newView.classList.remove('fade-in');
     }, 300); // アニメーション終了後にクラスを除去
+  }
+}
+
+// Aビュー用モーダルダイアログを表示
+export function showAViewModal() {
+  const modalDialog = document.getElementById('a-modal-dialog');
+  if (modalDialog) {
+    modalDialog.classList.add('active');
+  }
+  
+  // モーダルの閉じるボタンのイベントリスナーを設定
+  const closeButton = document.getElementById('modal-close');
+  if (closeButton) {
+    closeButton.addEventListener('click', closeAViewModal);
+  }
+}
+
+// Aビュー用モーダルダイアログを閉じる
+export function closeAViewModal() {
+  const modalDialog = document.getElementById('a-modal-dialog');
+  if (modalDialog) {
+    modalDialog.classList.remove('active');
+    
+    // メインビューに戻る
+    switchView('main');
   }
 }


### PR DESCRIPTION
## 概要
Aビューに専用のモーダルダイアログ機能を実装しました。

## 変更内容
- CSSにモーダルダイアログのスタイルを追加
- index.htmlにモーダルダイアログのマークアップを追加
- navigation.js にモーダル表示・非表示の制御機能を追加
- legacy.js からもモーダルが起動できるように修正

## 動作確認ポイント
- 「ビューA」タブをクリックすると、モーダルダイアログが表示される
- メイン画面の「A」ボタンをクリックしても同様にモーダルダイアログが表示される
- モーダルダイアログの右上の×ボタンをクリックすると、ダイアログが閉じてメインビューに戻る