### PR TITLE
B,Cビューにもモーダルダイアログを追加し、コードを共通化

### DIFF
--- a/css/components.css
+++ b/css/components.css
@@ -202,7 +202,7 @@ details[open] summary::after {
   background-color: #f0f2ff;
 }
 
-/* モーダルダイアログ */
+/* モーダルダイアログ共通スタイル */
 .modal-dialog {
   position: fixed;
   top: 0;
@@ -230,7 +230,6 @@ details[open] summary::after {
   width: 100%;
   padding: 1rem;
   text-align: center;
-  background-color: #eff6ff;
   border-bottom: 1px solid #d1d5db;
 }
 
@@ -250,7 +249,6 @@ details[open] summary::after {
   background: transparent;
   border: none;
   font-size: 24px;
-  color: #2563eb;
   cursor: pointer;
   width: 30px;
   height: 30px;
@@ -261,8 +259,45 @@ details[open] summary::after {
   transition: all 0.2s ease;
 }
 
-.modal-close:hover {
+/* ビューA用モーダルスタイル */
+.modal-a .modal-header {
+  background-color: #eff6ff;
+}
+
+.modal-a .modal-close {
+  color: #2563eb;
+}
+
+.modal-a .modal-close:hover {
   background-color: rgba(37, 99, 235, 0.1);
+  transform: scale(1.1);
+}
+
+/* ビューB用モーダルスタイル */
+.modal-b .modal-header {
+  background-color: #f5f3ff;
+}
+
+.modal-b .modal-close {
+  color: #9333ea;
+}
+
+.modal-b .modal-close:hover {
+  background-color: rgba(147, 51, 234, 0.1);
+  transform: scale(1.1);
+}
+
+/* ビューC用モーダルスタイル */
+.modal-c .modal-header {
+  background-color: #fdf2f8;
+}
+
+.modal-c .modal-close {
+  color: #db2777;
+}
+
+.modal-c .modal-close:hover {
+  background-color: rgba(219, 39, 119, 0.1);
   transform: scale(1.1);
 }
 

--- a/index.html
+++ b/index.html
@@ -86,17 +86,47 @@
       </div>
     </div>
     
-    <!-- Aビュー用モーダルダイアログ -->
-    <div class="modal-dialog" id="a-modal-dialog">
+    <!-- ビュー用モーダルダイアログ -->
+    <div class="modal-dialog modal-a" id="modal-a" data-view="a">
       <div class="modal-header">
         <h2>ビューA - モーダルダイアログ</h2>
-        <button class="modal-close" id="modal-close">&times;</button>
+        <button class="modal-close" data-view="a">&times;</button>
       </div>
       <div class="modal-content">
         <div class="text-center">
           <div class="text-xl font-bold mb-4" style="color: #2563eb;">ビューAのモーダルコンテンツ</div>
           <p class="mb-4">これはビューAで表示されるモーダルダイアログです。画面いっぱいに表示され、右上の×ボタンをクリックすると閉じることができます。</p>
           <p>このダイアログ内に今後、ビューA専用の機能を実装していきます。</p>
+        </div>
+      </div>
+    </div>
+    
+    <!-- ビューB用モーダルダイアログ -->
+    <div class="modal-dialog modal-b" id="modal-b" data-view="b">
+      <div class="modal-header">
+        <h2>ビューB - モーダルダイアログ</h2>
+        <button class="modal-close" data-view="b">&times;</button>
+      </div>
+      <div class="modal-content">
+        <div class="text-center">
+          <div class="text-xl font-bold mb-4" style="color: #9333ea;">ビューBのモーダルコンテンツ</div>
+          <p class="mb-4">これはビューBで表示されるモーダルダイアログです。画面いっぱいに表示され、右上の×ボタンをクリックすると閉じることができます。</p>
+          <p>このダイアログ内に今後、ビューB専用の機能を実装していきます。</p>
+        </div>
+      </div>
+    </div>
+    
+    <!-- ビューC用モーダルダイアログ -->
+    <div class="modal-dialog modal-c" id="modal-c" data-view="c">
+      <div class="modal-header">
+        <h2>ビューC - モーダルダイアログ</h2>
+        <button class="modal-close" data-view="c">&times;</button>
+      </div>
+      <div class="modal-content">
+        <div class="text-center">
+          <div class="text-xl font-bold mb-4" style="color: #db2777;">ビューCのモーダルコンテンツ</div>
+          <p class="mb-4">これはビューCで表示されるモーダルダイアログです。画面いっぱいに表示され、右上の×ボタンをクリックすると閉じることができます。</p>
+          <p>このダイアログ内に今後、ビューC専用の機能を実装していきます。</p>
         </div>
       </div>
     </div>

--- a/js/legacy.js
+++ b/js/legacy.js
@@ -1,5 +1,5 @@
-// navigation.jsからswitchViewとshowAViewModal関数をインポート
-import { switchView, showAViewModal } from './navigation.js';
+// navigation.jsからswitchViewとshowViewModal関数をインポート
+import { switchView, showViewModal } from './navigation.js';
 
 // レガシーボタンの設定
 export function setupLegacyButtons() {
@@ -11,19 +11,23 @@ export function setupLegacyButtons() {
     buttonA.addEventListener('click', function() {
       switchView('a');
       // Aボタンクリック時にもモーダルを表示
-      showAViewModal();
+      showViewModal('a');
     });
   }
   
   if (buttonB) {
     buttonB.addEventListener('click', function() {
       switchView('b');
+      // Bボタンクリック時にもモーダルを表示
+      showViewModal('b');
     });
   }
   
   if (buttonC) {
     buttonC.addEventListener('click', function() {
       switchView('c');
+      // Cボタンクリック時にもモーダルを表示
+      showViewModal('c');
     });
   }
 }

--- a/js/navigation.js
+++ b/js/navigation.js
@@ -8,13 +8,16 @@ export function setupTabButtons() {
       if (viewName) {
         switchView(viewName);
         
-        // ビューAの場合はモーダルダイアログを表示
-        if (viewName === 'a') {
-          showAViewModal();
+        // メインビュー以外はモーダルダイアログを表示
+        if (viewName !== 'main') {
+          showViewModal(viewName);
         }
       }
     });
   });
+  
+  // モーダルの閉じるボタンのイベントリスナーを設定
+  setupModalCloseButtons();
 }
 
 // ビューを切り替える
@@ -63,27 +66,42 @@ export function switchView(viewName) {
   }
 }
 
-// Aビュー用モーダルダイアログを表示
-export function showAViewModal() {
-  const modalDialog = document.getElementById('a-modal-dialog');
+// モーダルダイアログの閉じるボタンのイベントリスナーを設定
+function setupModalCloseButtons() {
+  const closeButtons = document.querySelectorAll('.modal-close');
+  closeButtons.forEach(button => {
+    button.addEventListener('click', function() {
+      const viewName = this.getAttribute('data-view');
+      closeViewModal(viewName);
+    });
+  });
+}
+
+// ビュー用モーダルダイアログを表示
+export function showViewModal(viewName) {
+  const modalDialog = document.getElementById(`modal-${viewName}`);
   if (modalDialog) {
     modalDialog.classList.add('active');
   }
-  
-  // モーダルの閉じるボタンのイベントリスナーを設定
-  const closeButton = document.getElementById('modal-close');
-  if (closeButton) {
-    closeButton.addEventListener('click', closeAViewModal);
-  }
 }
 
-// Aビュー用モーダルダイアログを閉じる
-export function closeAViewModal() {
-  const modalDialog = document.getElementById('a-modal-dialog');
+// ビュー用モーダルダイアログを閉じる
+export function closeViewModal(viewName) {
+  const modalDialog = document.getElementById(`modal-${viewName}`);
   if (modalDialog) {
     modalDialog.classList.remove('active');
     
     // メインビューに戻る
     switchView('main');
   }
+}
+
+// 旧メソッド（互換性のため残しています）
+export function showAViewModal() {
+  showViewModal('a');
+}
+
+// 旧メソッド（互換性のため残しています）
+export function closeAViewModal() {
+  closeViewModal('a');
 }


### PR DESCRIPTION
## 概要
B,Cビューにも同様のモーダルダイアログ機能を追加し、コードを共通化しました。

## 変更内容
- HTMLに各ビュー(A,B,C)用のモーダルダイアログを追加
- CSSを修正し、モーダルスタイルを共通化した上で各ビュー専用のテーマカラーを適用
- JavaScriptのモーダルダイアログ表示・非表示機能を共通化
  - `showViewModal()`, `closeViewModal()` という汎用関数を作成
  - ビュー名をパラメータとして受け取り、該当するモーダルを操作
  - 後方互換性のため、既存関数も残しています
- レガシーボタンからのモーダル表示機能も共通化

## 動作確認ポイント
- 「ビューA/B/C」タブをクリックすると、対応するモーダルダイアログが表示される
- メイン画面の「A/B/C」ボタンをクリックしても同様に対応するモーダルダイアログが表示される
- 各モーダルダイアログの右上の×ボタンをクリックすると、そのダイアログが閉じてメインビューに戻る
- 各モーダルダイアログのヘッダー色と閉じるボタンの色が、対応するビューのテーマカラーになっている