### PR TITLE
ビューAからの新規ページ遷移機能を追加

### DIFF
--- a/css/components.css
+++ b/css/components.css
@@ -132,6 +132,41 @@
   background-color: #be185d;
 }
 
+/* 新規ページボタン */
+.primary-button {
+  padding: 0.6rem 1.2rem;
+  background-color: #059669;
+  color: white;
+  border: none;
+  border-radius: 4px;
+  cursor: pointer;
+  transition: all 0.3s ease;
+  font-weight: 500;
+}
+
+.primary-button:hover {
+  background-color: #047857;
+  transform: translateY(-2px);
+  box-shadow: 0 4px 8px rgba(0, 0, 0, 0.1);
+}
+
+.secondary-button {
+  padding: 0.6rem 1.2rem;
+  background-color: #6b7280;
+  color: white;
+  border: none;
+  border-radius: 4px;
+  cursor: pointer;
+  transition: all 0.3s ease;
+  font-weight: 500;
+}
+
+.secondary-button:hover {
+  background-color: #4b5563;
+  transform: translateY(-2px);
+  box-shadow: 0 4px 8px rgba(0, 0, 0, 0.1);
+}
+
 /* ホバー状態表示のスタイル */
 .hover-status {
   margin-top: 1rem;

--- a/css/layout.css
+++ b/css/layout.css
@@ -50,6 +50,12 @@
   border-radius: 0 0 6px 6px;
 }
 
+/* 新規ページ */
+.view-new-page {
+  background-color: #ecfdf5;
+  border-radius: 0 0 6px 6px;
+}
+
 /* コンテンツ切り替えアニメーション */
 @keyframes fadeIn {
   from {

--- a/index.html
+++ b/index.html
@@ -64,6 +64,10 @@
             <div class="text-lg font-bold" style="color: #2563eb;">A</div>
             <p>これはビューAのコンテンツです。以前はポップアップウィンドウでしたが、現在は単一ウィンドウ内のビューに変更されました。</p>
           </div>
+          <!-- 新規ページへのリンクボタンを追加 -->
+          <div class="text-center mt-4">
+            <button id="new-page-button" class="primary-button">新規ページへ</button>
+          </div>
         </div>
         
         <!-- ビューB -->
@@ -81,6 +85,18 @@
           <div class="text-center mb-4">
             <div class="text-lg font-bold" style="color: #db2777;">C</div>
             <p>これはビューCのコンテンツです。すべてのビューは同じウィンドウ内で切り替わり、スムーズなアニメーションが適用されます。</p>
+          </div>
+        </div>
+
+        <!-- 新規ページ -->
+        <div class="view view-new-page" id="view-new-page">
+          <h2 class="text-center">新規ページ</h2>
+          <div class="text-center mb-4">
+            <div class="text-lg font-bold" style="color: #059669;">新規</div>
+            <p>これは新規追加されたページです。ビューAから遷移することができます。</p>
+          </div>
+          <div class="text-center mt-4">
+            <button id="back-to-a-button" class="secondary-button">ビューAに戻る</button>
           </div>
         </div>
       </div>

--- a/js/navigation.js
+++ b/js/navigation.js
@@ -18,6 +18,80 @@ export function setupTabButtons() {
   
   // モーダルの閉じるボタンのイベントリスナーを設定
   setupModalCloseButtons();
+  
+  // 新規ページへのボタンとバックボタンのイベントリスナーを設定
+  setupNewPageNavigation();
+}
+
+// 新規ページナビゲーションの設定
+function setupNewPageNavigation() {
+  // 新規ページへのボタン
+  const newPageButton = document.getElementById('new-page-button');
+  if (newPageButton) {
+    newPageButton.addEventListener('click', function() {
+      navigateToNewPage();
+    });
+  }
+  
+  // ビューAに戻るボタン
+  const backToAButton = document.getElementById('back-to-a-button');
+  if (backToAButton) {
+    backToAButton.addEventListener('click', function() {
+      navigateBackToViewA();
+    });
+  }
+}
+
+// 新規ページへ遷移
+export function navigateToNewPage() {
+  console.log('Navigating to new page');
+  
+  // モーダルを閉じる
+  const modalA = document.getElementById('modal-a');
+  if (modalA && modalA.classList.contains('active')) {
+    modalA.classList.remove('active');
+  }
+  
+  // 新規ページに切り替え
+  switchToNewPage();
+}
+
+// ビューAに戻る
+export function navigateBackToViewA() {
+  console.log('Navigating back to View A');
+  
+  // 新規ページから戻る
+  switchView('a');
+  
+  // モーダルを表示
+  showViewModal('a');
+}
+
+// 新規ページへの切り替え
+function switchToNewPage() {
+  // 現在のアクティブビューを非表示にする
+  const currentView = document.querySelector('.view.active');
+  
+  if (currentView) {
+    currentView.classList.remove('active');
+  }
+  
+  // タブからアクティブクラスを削除
+  const activeTab = document.querySelector('.nav-tab.active');
+  if (activeTab) {
+    activeTab.classList.remove('active');
+    activeTab.classList.add('tab-hover-inactive');
+  }
+  
+  // 新規ページをアクティブに
+  const newPageView = document.getElementById('view-new-page');
+  if (newPageView) {
+    newPageView.classList.add('active');
+    newPageView.classList.add('fade-in');
+    setTimeout(() => {
+      newPageView.classList.remove('fade-in');
+    }, 300);
+  }
 }
 
 // ビューを切り替える


### PR DESCRIPTION
# 新規ページ遷移機能の追加

## 変更点
- ビューAに「新規ページへ」ボタンを追加
- 新規ページビューを実装
- 新規ページから「ビューAに戻る」ボタンを実装
- ページ遷移ロジックを実装
- 新規ページ用のスタイルを追加

## 動作確認方法
1. ビューAタブをクリック
2. 「新規ページへ」ボタンをクリック
3. 新規ページが表示されることを確認
4. 「ビューAに戻る」ボタンをクリック
5. ビューAに戻ることを確認