### PR TITLE
fix: POPボタンクリック時にメッセージダイアログを表示するよう修正

### DIFF
--- a/js/popbuttons.js
+++ b/js/popbuttons.js
@@ -1,4 +1,7 @@
 // POPボタンの機能実装
+// @ts-ignore
+const { dialog } = window.__TAURI__ || { dialog: { message: (msg) => alert(msg) } };
+
 export function setupPopButtons() {
   const popButtonA = document.getElementById('popButtonA');
   const popButtonB = document.getElementById('popButtonB');
@@ -6,7 +9,8 @@ export function setupPopButtons() {
   
   // ポップアップメッセージを表示する関数
   function showPopMessage() {
-    alert('POP!');
+    // Tauriダイアログを使用
+    dialog.message('POP!');
   }
   
   // 各ボタンにイベントリスナーを設定

--- a/src-tauri/tauri.conf.json
+++ b/src-tauri/tauri.conf.json
@@ -19,6 +19,10 @@
       "window": {
         "all": true
       },
+      "dialog": {
+        "all": true,
+        "message": true
+      },
       "shell": {
         "all": false,
         "open": true


### PR DESCRIPTION
## 内容
ビューA/B/C の「POP」ボタンを押してもメッセージダイアログが表示されない問題を修正しました。

## 修正内容
1. JavaScriptのネイティブalert関数の代わりに、Tauriのdialog APIを使用するように変更
2. Tauri設定ファイル（tauri.conf.json）にdialogモジュールを許可リストに追加

## 確認手順
1. 各ビュー（A, B, C）の「POP」ボタンをクリックする
2. 「POP!」というメッセージのダイアログが表示されることを確認

## 関連情報
- Tauriではネイティブのalert関数が正しく機能しないため、Tauri固有のAPIを使用するよう変更しました
- window.__TAURI__がない場合はフォールバック（通常のalert関数）も用意しているので、ブラウザでのデバッグも引き続き可能です