### PR TITLE
fix: POPボタンダイアログ表示の確実な実装（バックアップ機能追加）

### DIFF
--- a/js/popbuttons.js
+++ b/js/popbuttons.js
@@ -4,22 +4,96 @@ export function setupPopButtons() {
   const popButtonB = document.getElementById('popButtonB');
   const popButtonC = document.getElementById('popButtonC');
   
+  // カスタム・ポップアップメッセージを表示する関数
+  function showCustomPopup(message) {
+    // 既存のポップアップを削除
+    const existingPopup = document.getElementById('customPopup');
+    if (existingPopup) {
+      existingPopup.remove();
+    }
+    
+    // ポップアップ要素を作成
+    const popup = document.createElement('div');
+    popup.id = 'customPopup';
+    popup.style.position = 'fixed';
+    popup.style.top = '50%';
+    popup.style.left = '50%';
+    popup.style.transform = 'translate(-50%, -50%)';
+    popup.style.background = '#ffffff';
+    popup.style.padding = '20px';
+    popup.style.borderRadius = '8px';
+    popup.style.boxShadow = '0 4px 8px rgba(0, 0, 0, 0.2)';
+    popup.style.zIndex = '1000';
+    popup.style.minWidth = '200px';
+    popup.style.textAlign = 'center';
+    
+    // メッセージ要素
+    const messageElement = document.createElement('div');
+    messageElement.textContent = message;
+    messageElement.style.marginBottom = '15px';
+    messageElement.style.fontSize = '16px';
+    popup.appendChild(messageElement);
+    
+    // OKボタン
+    const okButton = document.createElement('button');
+    okButton.textContent = 'OK';
+    okButton.style.padding = '5px 15px';
+    okButton.style.borderRadius = '4px';
+    okButton.style.border = 'none';
+    okButton.style.background = '#3b82f6';
+    okButton.style.color = 'white';
+    okButton.style.cursor = 'pointer';
+    
+    okButton.addEventListener('click', function() {
+      popup.remove();
+    });
+    
+    popup.appendChild(okButton);
+    
+    // オーバーレイを作成
+    const overlay = document.createElement('div');
+    overlay.style.position = 'fixed';
+    overlay.style.top = '0';
+    overlay.style.left = '0';
+    overlay.style.width = '100%';
+    overlay.style.height = '100%';
+    overlay.style.background = 'rgba(0, 0, 0, 0.5)';
+    overlay.style.zIndex = '999';
+    
+    overlay.addEventListener('click', function() {
+      popup.remove();
+      overlay.remove();
+    });
+    
+    // ボディに追加
+    document.body.appendChild(overlay);
+    document.body.appendChild(popup);
+    
+    // フォーカスをOKボタンに設定
+    okButton.focus();
+  }
+  
   // ポップアップメッセージを表示する関数
   async function showPopMessage() {
     try {
-      // Tauriが利用可能かチェック
+      // Tauriが利用可能かチェックして、APIを使用
       if (window.__TAURI__) {
-        // Tauriのdialogモジュールを動的にインポート
-        const { message } = await import('@tauri-apps/api/dialog');
-        await message('POP!', { title: 'Queuelip' });
+        try {
+          const { dialog } = await import('@tauri-apps/api');
+          await dialog.message('POP!');
+        } catch (e) {
+          console.error("Tauriダイアログモジュール読み込みエラー:", e);
+          // フォールバック：カスタムポップアップを表示
+          showCustomPopup('POP!');
+        }
       } else {
-        // フォールバックとして標準のalertを使用
-        alert('POP!');
+        // ブラウザ環境の場合はカスタムポップアップを表示
+        showCustomPopup('POP!');
       }
     } catch (error) {
-      // エラーが発生した場合は標準のalertを使用
       console.error('Dialog error:', error);
-      alert('POP!');
+      // 最終フォールバック
+      showCustomPopup('POP!');
     }
   }
   

--- a/js/popbuttons.js
+++ b/js/popbuttons.js
@@ -5,8 +5,22 @@ export function setupPopButtons() {
   const popButtonC = document.getElementById('popButtonC');
   
   // ポップアップメッセージを表示する関数
-  function showPopMessage() {
-    alert('POP!');
+  async function showPopMessage() {
+    try {
+      // Tauriが利用可能かチェック
+      if (window.__TAURI__) {
+        // Tauriのdialogモジュールを動的にインポート
+        const { message } = await import('@tauri-apps/api/dialog');
+        await message('POP!', { title: 'Queuelip' });
+      } else {
+        // フォールバックとして標準のalertを使用
+        alert('POP!');
+      }
+    } catch (error) {
+      // エラーが発生した場合は標準のalertを使用
+      console.error('Dialog error:', error);
+      alert('POP!');
+    }
   }
   
   // 各ボタンにイベントリスナーを設定

--- a/src-tauri/tauri.conf.json
+++ b/src-tauri/tauri.conf.json
@@ -16,6 +16,14 @@
         "readText": true,
         "writeText": true
       },
+      "dialog": {
+        "all": true,
+        "open": true,
+        "save": true,
+        "message": true,
+        "ask": true,
+        "confirm": true
+      },
       "window": {
         "all": true
       },


### PR DESCRIPTION
## 内容
前回の修正で、ビューA/B/C の「POP」ボタンを押してもメッセージダイアログが表示されない問題が解決されていなかったため、さらに修正を行いました。

## 修正内容
1. TauriのダイアログAPIを正しく使用するように修正（@tauri-apps/apiからimport）
2. Tauri設定ファイル（tauri.conf.json）のDialogモジュール設定を詳細に構成
3. カスタムフォールバックダイアログ機能を実装して、Tauriダイアログが使用できない場合でも必ずメッセージが表示されるよう保証

## 技術的詳細
- 動的importを使用してTauriのdialogモジュールを読み込み
- エラーハンドリングを強化し、複数の段階でフォールバックを提供
- カスタムHTMLダイアログを実装し、Tauriの機能が使えない場合でも視覚的フィードバックを確保

## 確認手順
1. 各ビュー（A, B, C）の「POP」ボタンをクリックする
2. 「POP!」というメッセージのダイアログが表示されることを確認

## 関連情報
- この修正により、Tauriネイティブダイアログ、またはカスタムダイアログのいずれかでメッセージが必ず表示されるようになります