### PR TITLE
[実装完了] タブフォーカスナビゲーション修正 - inert属性によるフォーカス制御

### DIFF
--- a/css/utilities.css
+++ b/css/utilities.css
@@ -70,3 +70,17 @@
   background-color: #f9f9f9;
   transition: all 0.3s ease;
 }
+
+/* inert属性が適用された要素の視覚的フィードバック */
+[inert] {
+  cursor: default;
+  opacity: 0.5;
+  filter: grayscale(50%);
+  user-select: none;
+}
+
+/* inert属性が適用されたビューの調整 */
+.view[inert] {
+  opacity: 0;
+  pointer-events: none;
+}

--- a/js/navigation.js
+++ b/js/navigation.js
@@ -12,6 +12,20 @@ export function setupTabButtons() {
       }
     });
   });
+  
+  // 初期化時に非アクティブなビューにinert属性を設定
+  initializeInertViews();
+}
+
+// 初期化時に非アクティブなビューにinert属性を設定
+function initializeInertViews() {
+  const allViews = document.querySelectorAll('.view');
+  
+  allViews.forEach(function(view) {
+    if (!view.classList.contains('active')) {
+      view.setAttribute('inert', '');
+    }
+  });
 }
 
 // ビューを切り替える（テンプレート文字列アプローチ対応）
@@ -24,6 +38,8 @@ export function switchView(viewName) {
   
   if (currentView) {
     currentView.classList.remove('active');
+    // 非アクティブになったビューにinert属性を追加
+    currentView.setAttribute('inert', '');
   }
   
   if (currentTab) {
@@ -47,6 +63,8 @@ export function switchView(viewName) {
     }
     
     newView.classList.add('active');
+    // アクティブになったビューからinert属性を削除
+    newView.removeAttribute('inert');
     viewManager.setCurrentView(viewName);
   }
   


### PR DESCRIPTION
## 実装内容

### 問題
タブ切り替えUIで、非表示のビューの要素にもTabキーでフォーカスが移動してしまう問題を修正しました。
例：ビューA表示中に、見えていないメインビューの要素にフォーカスが移っていた。

### 解決策
`inert`属性を使用して、非アクティブなビューを完全に非インタラクティブにしました。

### 変更ファイル
- `js/navigation.js`: 
  - ビュー切り替え時に`inert`属性を動的に追加/削除
  - 初期化時に非アクティブなビューに`inert`属性を設定
- `css/utilities.css`: 
  - `inert`属性が適用された要素の視覚的フィードバックを追加

### 効果
- 非表示のビューの要素にTabキーでフォーカスが移らなくなる
- スクリーンリーダーも非表示のビューを無視する
- ユーザビリティとアクセシビリティの向上