### PR TITLE
[実装完了] Mini Window Popup機能 - ベゼルレス半透明ウィンドウ

### DIFF
--- a/css/mini.css
+++ b/css/mini.css
@@ -1,0 +1,262 @@
+/* 
+ * Mini Window Styles
+ * ベゼルレス対応、半透明コンテナ仕様
+ */
+
+/* === 設定オプション === */
+:root {
+    /* オプション切り替え用変数 */
+    --mini-bg-opacity: 0.9;              /* 半透明度 (0.0-1.0) */
+    --mini-bg-color: rgba(30, 30, 30, var(--mini-bg-opacity));
+    --mini-border-radius: 12px;          /* 角の丸み */
+    --mini-backdrop-blur: 10px;          /* 背景ブラー効果 */
+    
+    /* カラーテーマ */
+    --mini-accent-color: #3b82f6;        /* アクセントカラー */
+    --mini-text-primary: #ffffff;        /* メインテキスト */
+    --mini-text-secondary: #d1d5db;      /* サブテキスト */
+    --mini-border-color: rgba(75, 85, 99, 0.3);
+    
+    /* アニメーション */
+    --mini-transition: all 0.2s ease-in-out;
+}
+
+/* === ベースレイアウト === */
+body {
+    margin: 0;
+    padding: 0;
+    font-family: -apple-system, BlinkMacSystemFont, "Segoe UI", Roboto, sans-serif;
+    background: transparent;
+    overflow: hidden;
+}
+
+.mini-container {
+    width: 100vw;
+    height: 100vh;
+    background: var(--mini-bg-color);
+    backdrop-filter: blur(var(--mini-backdrop-blur));
+    border-radius: var(--mini-border-radius);
+    border: 1px solid var(--mini-border-color);
+    box-shadow: 0 8px 32px rgba(0, 0, 0, 0.3);
+    display: flex;
+    flex-direction: column;
+    overflow: hidden;
+    transition: var(--mini-transition);
+}
+
+.mini-container:hover {
+    box-shadow: 0 12px 48px rgba(0, 0, 0, 0.4);
+}
+
+/* === ヘッダー === */
+.mini-header {
+    display: flex;
+    justify-content: space-between;
+    align-items: center;
+    padding: 12px 16px 8px 16px;
+    border-bottom: 1px solid var(--mini-border-color);
+    background: rgba(255, 255, 255, 0.05);
+    cursor: move; /* ドラッグ可能 */
+}
+
+.mini-title {
+    margin: 0;
+    font-size: 14px;
+    font-weight: 600;
+    color: var(--mini-text-primary);
+    user-select: none;
+}
+
+.close-button {
+    background: #ff5f56;
+    border: none;
+    border-radius: 50%;
+    width: 20px;
+    height: 20px;
+    color: white;
+    font-size: 12px;
+    font-weight: bold;
+    cursor: pointer;
+    display: flex;
+    align-items: center;
+    justify-content: center;
+    transition: var(--mini-transition);
+    box-shadow: 0 2px 4px rgba(0, 0, 0, 0.2);
+}
+
+.close-button:hover {
+    background: #ff3b30;
+    transform: scale(1.1);
+    box-shadow: 0 4px 8px rgba(0, 0, 0, 0.3);
+}
+
+.close-button:active {
+    transform: scale(0.95);
+}
+
+/* === コンテンツエリア === */
+.mini-content {
+    flex: 1;
+    padding: 16px;
+    overflow-y: auto;
+    scrollbar-width: thin;
+    scrollbar-color: var(--mini-accent-color) transparent;
+}
+
+.mini-content::-webkit-scrollbar {
+    width: 6px;
+}
+
+.mini-content::-webkit-scrollbar-track {
+    background: transparent;
+}
+
+.mini-content::-webkit-scrollbar-thumb {
+    background: var(--mini-accent-color);
+    border-radius: 3px;
+}
+
+/* === アコーディオン === */
+.mini-accordion {
+    margin-bottom: 12px;
+    border: 1px solid var(--mini-border-color);
+    border-radius: 8px;
+    background: rgba(255, 255, 255, 0.05);
+    transition: var(--mini-transition);
+}
+
+.mini-accordion:hover {
+    background: rgba(255, 255, 255, 0.08);
+    border-color: var(--mini-accent-color);
+}
+
+.mini-accordion summary {
+    padding: 12px 16px;
+    cursor: pointer;
+    user-select: none;
+    font-weight: 500;
+    color: var(--mini-text-primary);
+    list-style: none;
+    position: relative;
+    transition: var(--mini-transition);
+}
+
+.mini-accordion summary::-webkit-details-marker {
+    display: none;
+}
+
+.mini-accordion summary::after {
+    content: '▼';
+    position: absolute;
+    right: 16px;
+    font-size: 10px;
+    color: var(--mini-accent-color);
+    transition: transform 0.2s ease;
+}
+
+.mini-accordion[open] summary::after {
+    transform: rotate(180deg);
+}
+
+.mini-accordion summary:hover {
+    background: rgba(255, 255, 255, 0.1);
+}
+
+.accordion-content {
+    padding: 0 16px 16px 16px;
+    border-top: 1px solid var(--mini-border-color);
+    animation: slideDown 0.2s ease-out;
+}
+
+@keyframes slideDown {
+    from {
+        opacity: 0;
+        transform: translateY(-10px);
+    }
+    to {
+        opacity: 1;
+        transform: translateY(0);
+    }
+}
+
+.accordion-content p {
+    margin: 12px 0 8px 0;
+    color: var(--mini-text-secondary);
+    font-size: 13px;
+    line-height: 1.5;
+}
+
+.accordion-content ul {
+    margin: 8px 0;
+    padding-left: 20px;
+    color: var(--mini-text-secondary);
+    font-size: 12px;
+}
+
+.accordion-content li {
+    margin-bottom: 4px;
+    line-height: 1.4;
+}
+
+/* === フッター === */
+.mini-footer {
+    padding: 8px 16px;
+    border-top: 1px solid var(--mini-border-color);
+    background: rgba(255, 255, 255, 0.03);
+    text-align: center;
+}
+
+.mini-footer small {
+    color: var(--mini-text-secondary);
+    font-size: 11px;
+    opacity: 0.8;
+}
+
+/* === レスポンシブ対応 === */
+@media (max-width: 400px) {
+    .mini-header {
+        padding: 10px 12px 6px 12px;
+    }
+    
+    .mini-title {
+        font-size: 13px;
+    }
+    
+    .close-button {
+        width: 18px;
+        height: 18px;
+        font-size: 11px;
+    }
+    
+    .mini-content {
+        padding: 12px;
+    }
+    
+    .mini-accordion summary {
+        padding: 10px 12px;
+        font-size: 13px;
+    }
+    
+    .accordion-content {
+        padding: 0 12px 12px 12px;
+    }
+}
+
+/* === 設定変更用クラス === */
+/* 完全透明背景モード */
+.mini-container.transparent-mode {
+    --mini-bg-color: rgba(0, 0, 0, 0.3);
+    --mini-backdrop-blur: 20px;
+}
+
+/* 常に最前面モード */
+.mini-container.always-on-top {
+    z-index: 9999;
+}
+
+/* 固定サイズモード */
+.mini-container.fixed-size {
+    resize: none;
+    width: 400px;
+    height: 350px;
+}

--- a/js/mini.js
+++ b/js/mini.js
@@ -1,0 +1,184 @@
+/**
+ * Mini Window JavaScript
+ * miniウィンドウ用のロジック
+ */
+
+// Tauri APIのインポート
+const { invoke } = window.__TAURI__.tauri;
+
+// DOM要素の取得
+let closeButton;
+let miniContainer;
+
+// 初期化
+document.addEventListener('DOMContentLoaded', function() {
+    initializeMiniWindow();
+    setupEventListeners();
+    console.log('Mini window JavaScript initialized');
+});
+
+/**
+ * Mini窓の初期化
+ */
+function initializeMiniWindow() {
+    closeButton = document.getElementById('closeButton');
+    miniContainer = document.querySelector('.mini-container');
+    
+    // 初期表示時のアニメーション
+    if (miniContainer) {
+        miniContainer.style.opacity = '0';
+        miniContainer.style.transform = 'scale(0.9)';
+        
+        setTimeout(() => {
+            miniContainer.style.transition = 'opacity 0.3s ease, transform 0.3s ease';
+            miniContainer.style.opacity = '1';
+            miniContainer.style.transform = 'scale(1)';
+        }, 50);
+    }
+}
+
+/**
+ * イベントリスナーの設定
+ */
+function setupEventListeners() {
+    // 閉じるボタンのクリックイベント
+    if (closeButton) {
+        closeButton.addEventListener('click', handleCloseWindow);
+    }
+    
+    // Escキーでの閉じる機能
+    document.addEventListener('keydown', function(event) {
+        if (event.key === 'Escape') {
+            handleCloseWindow();
+        }
+    });
+    
+    // アコーディオンのアニメーション強化
+    const accordions = document.querySelectorAll('.mini-accordion');
+    accordions.forEach(accordion => {
+        accordion.addEventListener('toggle', handleAccordionToggle);
+    });
+    
+    // ウィンドウのフォーカス管理
+    window.addEventListener('blur', handleWindowBlur);
+    window.addEventListener('focus', handleWindowFocus);
+}
+
+/**
+ * ウィンドウを閉じる処理
+ */
+async function handleCloseWindow() {
+    try {
+        console.log('Closing mini window...');
+        
+        // 閉じるアニメーション
+        if (miniContainer) {
+            miniContainer.style.transition = 'opacity 0.2s ease, transform 0.2s ease';
+            miniContainer.style.opacity = '0';
+            miniContainer.style.transform = 'scale(0.9)';
+        }
+        
+        // 少し待ってからRustコマンドを実行
+        setTimeout(async () => {
+            try {
+                await invoke('close_mini_window');
+                console.log('Mini window closed successfully');
+            } catch (error) {
+                console.error('Error closing mini window:', error);
+                // エラーが発生してもウィンドウは閉じる
+                window.close();
+            }
+        }, 200);
+        
+    } catch (error) {
+        console.error('Error in handleCloseWindow:', error);
+        // フォールバック: 直接ウィンドウを閉じる
+        window.close();
+    }
+}
+
+/**
+ * アコーディオンの開閉アニメーション
+ */
+function handleAccordionToggle(event) {
+    const accordion = event.target;
+    const content = accordion.querySelector('.accordion-content');
+    
+    if (content) {
+        if (accordion.open) {
+            // 開く時のアニメーション
+            content.style.animation = 'slideDown 0.3s ease-out';
+        } else {
+            // 閉じる時のアニメーション
+            content.style.animation = 'slideUp 0.2s ease-in';
+        }
+    }
+}
+
+/**
+ * ウィンドウフォーカス喪失時の処理
+ */
+function handleWindowBlur() {
+    if (miniContainer) {
+        miniContainer.style.opacity = '0.8';
+    }
+}
+
+/**
+ * ウィンドウフォーカス時の処理
+ */
+function handleWindowFocus() {
+    if (miniContainer) {
+        miniContainer.style.opacity = '1';
+    }
+}
+
+/**
+ * 設定オプションの動的変更（将来の拡張用）
+ */
+function applyWindowOptions(options = {}) {
+    if (!miniContainer) return;
+    
+    // 透明度モード
+    if (options.transparentMode) {
+        miniContainer.classList.add('transparent-mode');
+    } else {
+        miniContainer.classList.remove('transparent-mode');
+    }
+    
+    // 最前面モード  
+    if (options.alwaysOnTop) {
+        miniContainer.classList.add('always-on-top');
+    } else {
+        miniContainer.classList.remove('always-on-top');
+    }
+    
+    // 固定サイズモード
+    if (options.fixedSize) {
+        miniContainer.classList.add('fixed-size');
+    } else {
+        miniContainer.classList.remove('fixed-size');
+    }
+}
+
+// スライドアップアニメーションのCSS追加
+const style = document.createElement('style');
+style.textContent = `
+    @keyframes slideUp {
+        from {
+            opacity: 1;
+            transform: translateY(0);
+        }
+        to {
+            opacity: 0;
+            transform: translateY(-10px);
+        }
+    }
+`;
+document.head.appendChild(style);
+
+// エクスポート（将来のモジュール化用）
+window.miniWindowAPI = {
+    close: handleCloseWindow,
+    applyOptions: applyWindowOptions
+};

--- a/js/view-loader.js
+++ b/js/view-loader.js
@@ -1,5 +1,5 @@
 // Tauri対応ビューマネージャー - 分離されたテンプレートアプローチ
-import { viewATemplate } from './views/view-a.js';
+import { viewATemplate, initializeViewA } from './views/view-a.js';
 import { viewBTemplate } from './views/view-b.js';
 import { viewCTemplate } from './views/view-c.js';
 
@@ -11,6 +11,13 @@ export class ViewManager {
       a: viewATemplate,
       b: viewBTemplate,
       c: viewCTemplate
+    };
+    
+    // ビュー初期化関数のマップ
+    this.viewInitializers = {
+      a: initializeViewA,
+      b: null, // 将来の拡張用
+      c: null  // 将来の拡張用
     };
   }
 
@@ -36,50 +43,77 @@ export class ViewManager {
     const htmlContent = this.getViewTemplate(viewName);
     container.innerHTML = htmlContent;
     
-    // POPボタンのイベントリスナーを設定
+    // 動的イベントリスナー設定（従来の実装）
     this.setupDynamicEventListeners(viewName);
+    
+    // ビュー固有の初期化関数を実行
+    this.initializeView(viewName);
     
     return true;
   }
 
-  // 動的に追加されたボタンのイベントリスナーを設定
+  // ビュー固有の初期化関数を実行
+  initializeView(viewName) {
+    const initializer = this.viewInitializers[viewName];
+    if (initializer && typeof initializer === 'function') {
+      try {
+        initializer();
+        console.log(`View ${viewName} initialized successfully`);
+      } catch (error) {
+        console.error(`Error initializing view ${viewName}:`, error);
+      }
+    }
+  }
+
+  // 動的に追加されたボタンのイベントリスナーを設定（レガシー対応）
   setupDynamicEventListeners(viewName) {
     if (viewName === 'a' || viewName === 'b' || viewName === 'c') {
       const popButton = document.getElementById(`popButton${viewName.toUpperCase()}`);
       if (popButton) {
-        // クリックイベントを設定
+        // ビューAの場合は新しい初期化関数を使用するため、ここでは設定しない
+        if (viewName === 'a') {
+          return; // initializeViewA()が処理する
+        }
+        
+        // ビューB、Cの場合は従来の処理
         popButton.addEventListener('click', (event) => this.handlePopClick(viewName, event));
       }
     }
   }
 
-  // POPボタンのクリックハンドラー
+  // POPボタンのクリックハンドラー（レガシー実装 - ビューB、C用）
   async handlePopClick(viewName, event) {
     event.preventDefault();
     
     console.log(`POP button clicked for view ${viewName.toUpperCase()}`);
     
-    // Tauriのinvokeが利用可能な場合のみ実行
-    if (window.__TAURI__ && window.__TAURI__.tauri) {
-      try {
-        const result = await window.__TAURI__.tauri.invoke('popup_window_command', {
-          message: `View ${viewName.toUpperCase()} からポップアップ!`
-        });
-        console.log('Popup result:', result);
-      } catch (error) {
-        console.error('Popup error:', error);
-        // フォールバック: 通常のアラート
+    // ビューB、C用の将来の拡張
+    if (viewName === 'b' || viewName === 'c') {
+      // Tauriのinvokeが利用可能な場合のみ実行
+      if (window.__TAURI__ && window.__TAURI__.tauri) {
+        try {
+          const result = await window.__TAURI__.tauri.invoke('popup_window_command', {
+            message: `View ${viewName.toUpperCase()} からポップアップ!`
+          });
+          console.log('Popup result:', result);
+        } catch (error) {
+          console.error('Popup error:', error);
+          // フォールバック: 通常のアラート
+          alert(`View ${viewName.toUpperCase()} からポップアップ!`);
+        }
+      } else {
+        // Tauri環境でない場合のフォールバック
         alert(`View ${viewName.toUpperCase()} からポップアップ!`);
       }
-    } else {
-      // Tauri環境でない場合のフォールバック
-      alert(`View ${viewName.toUpperCase()} からポップアップ!`);
     }
   }
 
   // 新しいビューテンプレートを追加（動的テンプレート追加用）
-  addViewTemplate(viewName, template) {
+  addViewTemplate(viewName, template, initializer = null) {
     this.viewTemplates[viewName] = template;
+    if (initializer) {
+      this.viewInitializers[viewName] = initializer;
+    }
   }
 
   // 分離されたテンプレートファイルからテンプレートを動的ロード
@@ -87,8 +121,16 @@ export class ViewManager {
     try {
       const module = await import(modulePath);
       const templateKey = `view${viewName.toUpperCase()}Template`;
+      const initializerKey = `initialize${viewName.toUpperCase()}`;
+      
       if (module[templateKey]) {
         this.viewTemplates[viewName] = module[templateKey];
+        
+        // 初期化関数がある場合は追加
+        if (module[initializerKey]) {
+          this.viewInitializers[viewName] = module[initializerKey];
+        }
+        
         return true;
       } else {
         console.error(`Template ${templateKey} not found in module ${modulePath}`);

--- a/js/views/view-a.js
+++ b/js/views/view-a.js
@@ -16,3 +16,45 @@ export const viewAConfig = {
   color: '#2563eb',
   buttonId: 'popButtonA'
 };
+
+// ビューA初期化関数（POPボタンのイベントリスナー追加）
+export function initializeViewA() {
+  const popButton = document.getElementById('popButtonA');
+  
+  if (popButton) {
+    popButton.addEventListener('click', async function() {
+      try {
+        console.log('POP button clicked - opening mini window');
+        
+        // ボタンの視覚的フィードバック
+        popButton.disabled = true;
+        popButton.textContent = 'OPENING...';
+        
+        // Tauri APIを使用してminiウィンドウを開く
+        if (window.__TAURI__ && window.__TAURI__.tauri) {
+          await window.__TAURI__.tauri.invoke('open_mini_window');
+          console.log('Mini window opened successfully');
+        } else {
+          console.error('Tauri API not available');
+          alert('Mini window feature requires Tauri environment');
+        }
+        
+      } catch (error) {
+        console.error('Error opening mini window:', error);
+        alert('Failed to open mini window: ' + error.message);
+      } finally {
+        // ボタンを元に戻す（少し遅延させて視覚的効果を持続）
+        setTimeout(() => {
+          if (popButton) {
+            popButton.disabled = false;
+            popButton.textContent = 'POP';
+          }
+        }, 1000);
+      }
+    });
+    
+    console.log('View A POP button initialized');
+  } else {
+    console.warn('POP button not found in View A');
+  }
+}

--- a/mini.html
+++ b/mini.html
@@ -1,0 +1,69 @@
+<!DOCTYPE html>
+<html lang="ja">
+<head>
+    <meta charset="UTF-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1.0">
+    <title>Mini View</title>
+    <link rel="stylesheet" href="css/base.css">
+    <link rel="stylesheet" href="css/mini.css">
+</head>
+<body>
+    <div class="mini-container">
+        <!-- ヘッダー（ドラッグエリア + 閉じるボタン） -->
+        <div class="mini-header" data-tauri-drag-region>
+            <h2 class="mini-title">Mini View</h2>
+            <button id="closeButton" class="close-button" title="閉じる">×</button>
+        </div>
+        
+        <!-- コンテンツエリア -->
+        <div class="mini-content">
+            <!-- アコーディオン1 -->
+            <details class="mini-accordion">
+                <summary>設定</summary>
+                <div class="accordion-content">
+                    <p>アプリケーションの基本設定を行います。</p>
+                    <ul>
+                        <li>表示モード: ダークテーマ</li>
+                        <li>言語: 日本語</li>
+                        <li>自動保存: 有効</li>
+                    </ul>
+                </div>
+            </details>
+            
+            <!-- アコーディオン2 -->
+            <details class="mini-accordion">
+                <summary>統計情報</summary>
+                <div class="accordion-content">
+                    <p>使用状況の統計データです。</p>
+                    <ul>
+                        <li>総使用時間: 24時間32分</li>
+                        <li>クリップ回数: 1,247回</li>
+                        <li>最後の使用: 2分前</li>
+                    </ul>
+                </div>
+            </details>
+            
+            <!-- アコーディオン3 -->
+            <details class="mini-accordion">
+                <summary>ヘルプ</summary>
+                <div class="accordion-content">
+                    <p>Queuelipの使用方法とヒントです。</p>
+                    <ul>
+                        <li>Ctrl+Cでコピー</li>
+                        <li>Ctrl+Vで貼り付け</li>
+                        <li>履歴は自動で管理されます</li>
+                    </ul>
+                </div>
+            </details>
+        </div>
+        
+        <!-- フッター -->
+        <div class="mini-footer">
+            <small>Mini View - Queuelip</small>
+        </div>
+    </div>
+    
+    <!-- JavaScript -->
+    <script type="module" src="js/mini.js"></script>
+</body>
+</html>

--- a/vite.config.js
+++ b/vite.config.js
@@ -20,5 +20,12 @@ export default defineConfig(async () => ({
     minify: !process.env.TAURI_DEBUG ? 'esbuild' : false,
     // produce sourcemaps for debug builds
     sourcemap: !!process.env.TAURI_DEBUG,
+    // 複数のHTMLファイルをビルド対象に追加
+    rollupOptions: {
+      input: {
+        main: 'index.html',
+        mini: 'mini.html'
+      }
+    }
   },
 }));


### PR DESCRIPTION
## 実装完了 - Mini Window Popup 機能

### 📋 実装内容
ビューAのPOPボタンからベゼルレスminiウィンドウを開く機能を実装しました。

### 🛠️ 追加・変更ファイル

#### **新規作成**
- `mini.html` - miniウィンドウのHTML構造（3つのアコーディオン + 閉じるボタン）
- `css/mini.css` - ベゼルレス半透明デザイン（オプション設定対応）
- `js/mini.js` - miniウィンドウのJavaScript制御

#### **修正**
- `src-tauri/src/main.rs` - mini窓の開閉Rustコマンド追加
- `js/views/view-a.js` - POPボタンでmini窓を開く機能追加
- `js/view-loader.js` - ビューA初期化関数呼び出し対応
- `vite.config.js` - mini.htmlをビルド対象に追加

### ✨ 機能仕様

#### **miniウィンドウの特徴**
- **ベゼルレス**: タイトルバーなしのフラットデザイン
- **半透明コンテナ**: 背景ブラー効果付き
- **通常ウィンドウ**: 最前面表示なし（オプション対応済み）
- **可変サイズ**: リサイズ可能（固定サイズオプション対応済み）

#### **設定オプション（将来の拡張対応）**
Rust側の`MINI_WINDOW_CONFIG`で以下を制御可能：
```rust
const MINI_WINDOW_CONFIG: MiniWindowConfig = MiniWindowConfig {
    transparent_background: false,  // 半透明コンテナ
    always_on_top: false,          // 通常ウィンドウ
    resizable: true,               // 可変サイズ
    width: 400.0,
    height: 350.0,
};
```

#### **UI要素**
- **ヘッダー**: ドラッグ可能エリア + 閉じるボタン
- **コンテンツ**: 3つのアコーディオン（設定、統計情報、ヘルプ）
- **フッター**: アプリ情報表示

### 🎯 動作仕様
1. **ビューA** → **POPボタンクリック** → **miniウィンドウ表示**
2. **miniウィンドウ** → **閉じるボタンクリック** → **ウィンドウ閉じる**
3. **Escキー**でもウィンドウ閉じる機能付き

### 🔧 技術的改善点
- Rustバックエンドでウィンドウ管理
- モジュール化されたビュー初期化システム
- 設定変更用のCSS変数アプローチ
- アニメーション効果付きUI

### ⚠️ 注意事項
- 既存のminiウィンドウがある場合は自動で閉じて新しく開く
- ビューB、CのPOP機能は従来通り（将来の拡張対応済み）
- Tauri環境でない場合のフォールバック処理対応

---

**動作確認**: 開発環境でテスト済み  
**次フェーズ**: バージョン更新 + 設計者による動作確認依頼