### PR TITLE
[緊急修正] ビルドエラー解消 - transparent()メソッド削除

### DIFF
--- a/src-tauri/src/main.rs
+++ b/src-tauri/src/main.rs
@@ -4,7 +4,6 @@ use tauri::{Manager, RunEvent};
 
 // miniウィンドウの設定オプション
 const MINI_WINDOW_CONFIG: MiniWindowConfig = MiniWindowConfig {
-    transparent_background: false,  // 半透明コンテナ用
     always_on_top: false,          // 通常ウィンドウ
     resizable: true,               // 可変サイズ
     width: 400.0,
@@ -12,7 +11,6 @@ const MINI_WINDOW_CONFIG: MiniWindowConfig = MiniWindowConfig {
 };
 
 struct MiniWindowConfig {
-    transparent_background: bool,
     always_on_top: bool,
     resizable: bool,
     width: f64,
@@ -34,11 +32,9 @@ async fn open_mini_window(app_handle: tauri::AppHandle) -> Result<(), String> {
     )
     .title("Mini View")
     .decorations(false)     // ベゼルレス
-    .transparent(MINI_WINDOW_CONFIG.transparent_background)
     .always_on_top(MINI_WINDOW_CONFIG.always_on_top)
     .resizable(MINI_WINDOW_CONFIG.resizable)
-    .width(MINI_WINDOW_CONFIG.width)
-    .height(MINI_WINDOW_CONFIG.height)
+    .inner_size(MINI_WINDOW_CONFIG.width, MINI_WINDOW_CONFIG.height)
     .build()
     .map_err(|e| e.to_string())?;
     
@@ -83,7 +79,7 @@ fn main() {
                 let app_handle = app.handle().clone();
                 main_window.on_window_event(move |event| {
                     match event {
-                        tauri::WindowEvent::CloseRequested { api, .. } => {
+                        tauri::WindowEvent::CloseRequested { .. } => {
                             println!("Main window close requested, exiting application");
                             // アプリケーション全体を終了
                             app_handle.exit(0);
@@ -101,7 +97,7 @@ fn main() {
         .expect("error while building tauri application")
         .run(|_app_handle, event| match event {
             // アプリケーション終了時
-            RunEvent::ExitRequested { api, .. } => {
+            RunEvent::ExitRequested { .. } => {
                 println!("Application exit requested");
                 // 終了を許可
                 _app_handle.exit(0);


### PR DESCRIPTION
## 緊急修正 - ビルドエラー解消

### 🚨 問題
Tauri WindowBuilderで`.transparent()`メソッドが利用できずビルドエラーが発生

### 🔧 修正内容
- `.transparent(MINI_WINDOW_CONFIG.transparent_background)` を削除
- `.width()`, `.height()` を `.inner_size()` に統合
- 未使用警告の`api`パラメータを削除

### ✅ 修正後の動作
- ベゼルレス（decorations: false）は維持
- 半透明効果はCSSで代替実装済み
- 基本的なminiウィンドウ作成・操作が正常動作

### 📝 技術的詳細
```rust
// 修正前（ビルドエラー）
.transparent(MINI_WINDOW_CONFIG.transparent_background)  // ❌ メソッドなし

// 修正後（正常）
.inner_size(MINI_WINDOW_CONFIG.width, MINI_WINDOW_CONFIG.height)  // ✅ 正常
```

### 🎯 影響範囲
- ウィンドウの基本機能は全て維持
- 透明効果はCSS側で実装（影響なし）
- ビルド成功による開発・テスト環境の正常化

---

**優先度**: 緊急（ビルドブロッカー解消）  
**テスト状況**: ローカルでビルド確認済み