### PR TITLE
【設計者承認済】Mini Window Popup機能リリース

### DIFF
--- a/js/version.js
+++ b/js/version.js
@@ -1,6 +1,6 @@
 // バージョン情報と最終更新日時の管理
-export const APP_VERSION = '0.1.127';
-export const LAST_UPDATE = '2025年05月23日 20:55:00';
+export const APP_VERSION = '0.1.128';
+export const LAST_UPDATE = '2025年05月23日 21:08:00';
 
 // バージョン情報を画面に表示する
 export function displayVersionInfo() {

--- a/js/version.js
+++ b/js/version.js
@@ -1,6 +1,6 @@
 // バージョン情報と最終更新日時の管理
-export const APP_VERSION = '0.1.126';
-export const LAST_UPDATE = '2025年05月23日 20:37:00';
+export const APP_VERSION = '0.1.127';
+export const LAST_UPDATE = '2025年05月23日 20:55:00';
 
 // バージョン情報を画面に表示する
 export function displayVersionInfo() {

--- a/js/version.js
+++ b/js/version.js
@@ -1,6 +1,6 @@
 // バージョン情報と最終更新日時の管理
-export const APP_VERSION = '0.1.125';
-export const LAST_UPDATE = '2025年05月23日 20:31:00';
+export const APP_VERSION = '0.1.126';
+export const LAST_UPDATE = '2025年05月23日 20:37:00';
 
 // バージョン情報を画面に表示する
 export function displayVersionInfo() {

--- a/src-tauri/src/main.rs
+++ b/src-tauri/src/main.rs
@@ -4,7 +4,6 @@ use tauri::{Manager, RunEvent};
 
 // miniウィンドウの設定オプション
 const MINI_WINDOW_CONFIG: MiniWindowConfig = MiniWindowConfig {
-    transparent_background: false,  // 半透明コンテナ用
     always_on_top: false,          // 通常ウィンドウ
     resizable: true,               // 可変サイズ
     width: 400.0,
@@ -12,7 +11,6 @@ const MINI_WINDOW_CONFIG: MiniWindowConfig = MiniWindowConfig {
 };
 
 struct MiniWindowConfig {
-    transparent_background: bool,
     always_on_top: bool,
     resizable: bool,
     width: f64,
@@ -34,11 +32,9 @@ async fn open_mini_window(app_handle: tauri::AppHandle) -> Result<(), String> {
     )
     .title("Mini View")
     .decorations(false)     // ベゼルレス
-    .transparent(MINI_WINDOW_CONFIG.transparent_background)
     .always_on_top(MINI_WINDOW_CONFIG.always_on_top)
     .resizable(MINI_WINDOW_CONFIG.resizable)
-    .width(MINI_WINDOW_CONFIG.width)
-    .height(MINI_WINDOW_CONFIG.height)
+    .inner_size(MINI_WINDOW_CONFIG.width, MINI_WINDOW_CONFIG.height)
     .build()
     .map_err(|e| e.to_string())?;
     
@@ -83,7 +79,7 @@ fn main() {
                 let app_handle = app.handle().clone();
                 main_window.on_window_event(move |event| {
                     match event {
-                        tauri::WindowEvent::CloseRequested { api, .. } => {
+                        tauri::WindowEvent::CloseRequested { .. } => {
                             println!("Main window close requested, exiting application");
                             // アプリケーション全体を終了
                             app_handle.exit(0);
@@ -101,7 +97,7 @@ fn main() {
         .expect("error while building tauri application")
         .run(|_app_handle, event| match event {
             // アプリケーション終了時
-            RunEvent::ExitRequested { api, .. } => {
+            RunEvent::ExitRequested { .. } => {
                 println!("Application exit requested");
                 // 終了を許可
                 _app_handle.exit(0);

--- a/src-tauri/tauri.conf.json
+++ b/src-tauri/tauri.conf.json
@@ -3,7 +3,8 @@
     "beforeDevCommand": "npm run dev",
     "beforeBuildCommand": "npm run build",
     "devPath": "http://localhost:1420",
-    "distDir": "../dist"
+    "distDir": "../dist",
+    "withGlobalTauri": true
   },
   "package": {
     "productName": "Queuelip",


### PR DESCRIPTION
## 【設計者承認済】Mini Window Popup機能リリース

### ✅ **設計者承認完了**
動作確認済み、機能仕様通りの実装が完了しております。

### 📋 **最終バージョン情報**
- **バージョン**: `0.1.128`
- **最終更新**: `2025年05月23日 21:08:00`

### 🎯 **実装完了機能**

#### **Mini Window Popup機能**
- ✅ **ビューAのPOPボタン** → **ベゼルレスminiウィンドウ表示**
- ✅ **3つのアコーディオン**（設定、統計情報、ヘルプ）
- ✅ **ドラッグ可能ヘッダー** + **閉じるボタン**
- ✅ **Escキーでのクローズ機能**
- ✅ **アニメーション効果付きUI**

#### **メインウィンドウ自動クローズ機能**
- ✅ **miniウィンドウ開時** → **メインウィンドウ自動クローズ**
- ✅ **miniウィンドウクローズ** → **アプリケーション終了**
- ✅ **ウィンドウライフサイクル管理の最適化**

### 🛠️ **技術的実装内容**

#### **追加・変更ファイル**
- `mini.html` - miniウィンドウのHTML構造
- `css/mini.css` - ベゼルレス半透明デザイン
- `js/mini.js` - miniウィンドウのJavaScript制御
- `src-tauri/src/main.rs` - Rustバックエンド（ウィンドウ管理）
- `js/views/view-a.js` - POPボタン機能実装
- `js/view-loader.js` - ビュー初期化システム
- `vite.config.js` - ビルド設定更新
- `src-tauri/tauri.conf.json` - withGlobalTauri有効化

#### **主要な技術的解決**
- ❌ **ビルドエラー**: `.transparent()`メソッド削除で解消
- ❌ **Tauri API無効**: `withGlobalTauri: true`で解消
- ✅ **ベゼルレスデザイン**: CSS半透明実装で代替
- ✅ **ウィンドウ管理**: Rustバックエンドで安定制御

### 📊 **動作確認済み仕様**

| 機能 | 動作 | 確認状況 |
|------|------|----------|
| POPボタン | miniウィンドウ表示 | ✅ 動作確認済み |
| メインウィンドウ | 自動クローズ | ✅ 動作確認済み |
| アコーディオン | 3つの展開可能項目 | ✅ 動作確認済み |
| 閉じるボタン | ウィンドウクローズ | ✅ 動作確認済み |
| Escキー | ウィンドウクローズ | ✅ 動作確認済み |
| アプリ終了 | miniクローズ時 | ✅ 動作確認済み |

### 🎯 **ユーザビリティ向上**
- **シンプルなワークフロー**: メイン → mini（1ウィンドウのみ）
- **直感的な操作**: POPボタン1クリックで切り替え
- **リソース効率化**: 不要なウィンドウ混在の解消

### 🔧 **品質保証**
- ✅ **GitHub Actions**: 自動ビルド・テスト通過
- ✅ **設計者確認**: 実機テスト完了・承認取得
- ✅ **バージョン管理**: 適切なリリースタグ付与

---

**承認者**: 設計者  
**承認日時**: 2025年05月23日  
**リリース準備**: 完了