### PR TITLE
[実装完了] ビルドスクリプト修正 - package.jsonにビルド設定追加

### DIFF
--- a/package.json
+++ b/package.json
@@ -4,13 +4,16 @@
   "description": "A clipboard manager with queue behavior",
   "main": "index.js",
   "scripts": {
-    "tauri": "tauri"
+    "tauri": "tauri",
+    "dev": "vite",
+    "build": "vite build"
   },
   "dependencies": {
     "@tauri-apps/api": "^1.5.0",
     "tauri-plugin-log-api": "github:tauri-apps/tauri-plugin-log#v1"
   },
   "devDependencies": {
-    "@tauri-apps/cli": "^1.5.0"
+    "@tauri-apps/cli": "^1.5.0",
+    "vite": "^4.4.5"
   }
 }


### PR DESCRIPTION
## 問題
GitHub Actionsでのビルド時に `npm run build` スクリプトが見つからないエラーが発生していました。

## 解決内容
package.jsonに以下を追加：

### スクリプト
- `"build": "vite build"` - Tauriビルド時に必要
- `"dev": "vite"` - 開発サーバー起動用

### 依存関係
- `"vite": "^4.4.5"` - ビルドツールとしてdevDependenciesに追加

## 変更ファイル
- `package.json` - ビルドスクリプトとVite依存関係の追加

## 効果
- GitHub Actionsでのビルドエラーが解消される
- 開発環境での `npm run dev` が使用可能になる
- Tauriの `beforeBuildCommand` が正常に動作する

## テスト確認事項
- [ ] `npm install` でViteがインストールされること
- [ ] `npm run build` でdistディレクトリが生成されること
- [ ] GitHub Actionsでビルドが成功すること