### PR TITLE
[実装完了] Vite HTMLプロキシエラー修正 - インラインスクリプトを外部ファイルに移動

### DIFF
--- a/js/mini-init.js
+++ b/js/mini-init.js
@@ -1,0 +1,26 @@
+// Mini window用ログシステム初期化
+import { attachConsole, info } from "tauri-plugin-log-api";
+
+// Mini window開始時にログを初期化
+export async function initMiniLogger() {
+  try {
+    const detach = await attachConsole();
+    console.log('Mini window log system initialized - console attached');
+    info('Mini window loaded - JavaScript log system active');
+    
+    // ウィンドウ終了時にデタッチ（必要に応じて）
+    window.addEventListener('beforeunload', () => {
+      if (detach) {
+        detach();
+      }
+    });
+    
+    return detach;
+  } catch (error) {
+    console.error('Failed to initialize mini window log system:', error);
+    throw error;
+  }
+}
+
+// ページ読み込み時に自動初期化
+initMiniLogger();

--- a/mini.html
+++ b/mini.html
@@ -7,27 +7,8 @@
     <link rel="stylesheet" href="css/base.css">
     <link rel="stylesheet" href="css/mini.css">
     
-    <!-- ログシステム初期化 -->
-    <script type="module">
-      // tauri-plugin-log-api をインポートしてWebviewコンソールに接続
-      import { attachConsole, info } from "tauri-plugin-log-api";
-      
-      // Mini window開始時にログを初期化
-      try {
-        const detach = await attachConsole();
-        console.log('Mini window log system initialized - console attached');
-        info('Mini window loaded - JavaScript log system active');
-        
-        // ウィンドウ終了時にデタッチ（必要に応じて）
-        window.addEventListener('beforeunload', () => {
-          if (detach) {
-            detach();
-          }
-        });
-      } catch (error) {
-        console.error('Failed to initialize mini window log system:', error);
-      }
-    </script>
+    <!-- ログシステム初期化 - 外部ファイルで実行 -->
+    <script type="module" src="js/mini-init.js"></script>
 </head>
 <body>
     <div class="mini-container">


### PR DESCRIPTION
## 問題
ViteビルドでHTMLプロキシエラーが発生していました：
```
[vite:html-inline-proxy] Could not load D:aqueuelipqueuelipmini.html?html-proxy&index=0.js (imported by mini.html): No matching HTML proxy module found
```

## 解決内容

### 1. インラインスクリプトを外部ファイルに移動
- `mini.html` 内のインラインスクリプトを `js/mini-init.js` に移動
- ログシステム初期化ロジックをモジュール化

### 2. HTML構造をクリーンアップ
- `mini.html` からインラインスクリプトを削除
- 外部ファイル参照に変更：`<script type="module" src="js/mini-init.js"></script>`

## 変更ファイル
- `js/mini-init.js` - 新規作成（ログ初期化ロジック）
- `mini.html` - インラインスクリプト削除、外部ファイル参照に変更

## 効果
- ViteビルドのHTMLプロキシエラーが解決される
- コードの保守性が向上（HTMLからロジックを分離）
- ビルドプロセスが正常に動作する

## 技術的詳細
ViteはHTMLファイル内のインラインスクリプトでESモジュールを使用する際、HTMLプロキシシステムを使用します。複数のHTMLファイル（index.html, mini.html）がある場合、このプロキシシステムが適切に動作しないことがあります。外部ファイルに移動することで、この問題を回避できます。