### PR TITLE
[実装完了] Rustコンパイルエラー修正 - 最終ビルド問題解決

### DIFF
--- a/src-tauri/src/main.rs
+++ b/src-tauri/src/main.rs
@@ -2,7 +2,7 @@
 
 use tauri::{Manager, RunEvent};
 use tauri_plugin_log::LogTarget;
-use log::{info, warn, error, debug};
+use log::{info, warn, error};
 
 // miniウィンドウの設定オプション
 const MINI_WINDOW_CONFIG: MiniWindowConfig = MiniWindowConfig {
@@ -104,9 +104,11 @@ async fn open_mini_window(app_handle: tauri::AppHandle) -> Result<(), String> {
             match event {
                 tauri::WindowEvent::CloseRequested { api, .. } => {
                     info!("=== Mini window close event detected ===");
-                    // ウィンドウを非表示にして閉じることを防ぐ
-                    if let Err(e) = event.window().hide() {
-                        error!("Failed to hide mini window: {}", e);
+                    // miniウィンドウを非表示にして閉じることを防ぐ
+                    if let Some(mini_window) = app_handle_clone.get_window("mini") {
+                        if let Err(e) = mini_window.hide() {
+                            error!("Failed to hide mini window: {}", e);
+                        }
                     }
                     api.prevent_close();
                     


### PR DESCRIPTION
## 問題
Rustコンパイル時に以下のエラーが発生していました：

1. **未使用import警告**:
   ```
   warning: unused import: `debug`
   --> src\main.rs:5:30
   ```

2. **メソッドエラー**:
   ```
   error[E0599]: no method named `window` found for reference `&tauri::WindowEvent`
   --> src\main.rs:108:43
   ```

## 解決内容

### 1. 未使用importの削除
- `use log::{info, warn, error, debug};` → `use log::{info, warn, error};`
- `debug` マクロが使用されていないため削除

### 2. WindowEvent処理の修正
**修正前:**
```rust
if let Err(e) = event.window().hide() {
```

**修正後:**
```rust
if let Some(mini_window) = app_handle_clone.get_window("mini") {
    if let Err(e) = mini_window.hide() {
```

## 技術的詳細
`tauri::WindowEvent` には `window()` メソッドが存在しません。正しくは `app_handle.get_window()` を使用してウィンドウインスタンスを取得し、そのインスタンスのメソッドを呼び出す必要があります。

## 変更ファイル
- `src-tauri/src/main.rs` - Rustコンパイルエラーの修正

## 効果
- Rustコンパイルエラーが解決される
- GitHub Actionsでのビルドが成功する
- Tauriアプリケーションのminiウィンドウイベント処理が正常に動作する